### PR TITLE
Allow to use underscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,15 @@
     ],
     "parserOptions": {
       "project": "./tsconfig.json"
+    },
+    "rules": {
+      "no-underscore-dangle": [
+        "error",
+        {
+          "allowAfterThis": true,
+          "enforceInMethodNames": true
+        }
+      ]
     }
   },
   "browserslist": {


### PR DESCRIPTION
こんな感じで書込不可/読取可な public メンバをやるために、private メンバは `_` 付きを許容させたいため

```ts
class Player {
  private _name: string;

  public get name(): string {
    return this._name;
  }

  public renameTo(name: string): void {
    this._name = name;
  }
}
```